### PR TITLE
Added Visible flag to Overlay.

### DIFF
--- a/Interface/Overlay.cs
+++ b/Interface/Overlay.cs
@@ -11,6 +11,8 @@ namespace NFive.SDK.Client.Interface
 
 		public string Name => GetType().Name;
 
+		public bool Visible = true;
+
 		protected Overlay(string fileName, OverlayManager manager)
 		{
 			this.Manager = manager;
@@ -25,11 +27,13 @@ namespace NFive.SDK.Client.Interface
 		public void Show()
 		{
 			this.Manager.Send("show", true);
+			this.Visible = true;
 		}
 
 		public void Hide()
 		{
 			this.Manager.Send("show", false);
+			this.Visible = false;
 		}
 
 		protected void Send(string @event, object data = null)


### PR DESCRIPTION
This is required if some overlay needs to track wether something is already visible or not.
Use case -> speedometer. This should show only when PED is in car.
You wouldn't want to make overlay show in beginning of each tick and then configure visibility again and again and again.