### PR TITLE
Add HoldFocus ordered startup event to Services

### DIFF
--- a/Services/Service.cs
+++ b/Services/Service.cs
@@ -37,6 +37,8 @@ namespace NFive.SDK.Client.Services
 
 		public virtual Task Started() => Task.FromResult(0);
 
+		public virtual Task HoldFocus() => Task.FromResult(0);
+
 		protected async Task Delay(int ms)
 		{
 			await BaseScript.Delay(ms);


### PR DESCRIPTION
Services can hold client focus one by one.